### PR TITLE
jasmine_sprout: use sysctl to control energy aware feature

### DIFF
--- a/arrow.dependencies
+++ b/arrow.dependencies
@@ -2,5 +2,9 @@
   {
     "repository": "android_device_xiaomi_sdm660-common",
     "target_path": "device/xiaomi/sdm660-common"
+  },
+  {
+    "repository": "android_vendor_xiaomi_wayne-common",
+    "target_path": "device/xiaomi/wayne-common"
   }
 ]

--- a/powerhint.json
+++ b/powerhint.json
@@ -94,6 +94,15 @@
       "ResetOnInit": true
     },
     {
+      "Name": "EnergyAware",
+      "Path": "/proc/sys/kernel/sched_energy_aware",
+      "Values": [
+        "0",
+        "1"
+      ],
+      "ResetOnInit": true
+    },
+    {
       "Name": "CPUBWHystTriggerCount",
       "Path": "/sys/class/devfreq/soc:qcom,cpubw/bw_hwmon/hyst_trigger_count",
       "Values": [
@@ -197,6 +206,12 @@
       "Node": "CPUBWMinFreq",
       "Duration": 0,
       "Value": "2929"
+    },
+    {
+      "PowerHint": "LAUNCH",
+      "Node": "EnergyAware",
+      "Duration": 2500,
+      "Value": "0"
     },
     {
       "PowerHint": "LAUNCH",


### PR DESCRIPTION
Energy aware feature control is previously done through debugfs,
which will be deprecated, so move the control to sysctl.

Bug: 141333728
Test: function works as expected
Change-Id: I431b3113aa6bcde48b4b7cf9b2097666b948ad80
Signed-off-by: Ratoriku <a1063021545@gmail.com>